### PR TITLE
Add sorting methods

### DIFF
--- a/docs/user-guide/manipulation.md
+++ b/docs/user-guide/manipulation.md
@@ -126,13 +126,25 @@ sf.data = sf.data.merge(external_data, on='sample_id', how='left')
 sf.data.loc[sf.data['group'] == 'Control', 'treatment'] = 'None'
 ```
 
+## Sorting
+
+You can sort spectra by row index or by metadata values, similar to pandas.
+Wavelengths can be sorted independently with `wl_sort`, which also reorders
+the spectral columns to match the new wavelength order.
+
+```python
+sf_sorted = sf.sort_index()
+sf_sorted = sf.sort_values("group")
+sf_sorted = sf.wl_sort()
+```
+
 ## Concatenation
 ```python
 # Combine multiple SpectraFrames
 combined = pyspc.concat([sf1, sf2, sf3])
 
 # Ensure consistent wavelength grids before concatenation
-sf2_aligned = sf2.resample_wl(sf1.wl)
+sf2_aligned = sf2.wl_resample(sf1.wl)
 combined = pyspc.concat([sf1, sf2_aligned])
 ```
 

--- a/docs/user-guide/preprocessing.md
+++ b/docs/user-guide/preprocessing.md
@@ -137,10 +137,10 @@ The method passes data to [`scipy.interpolate.interp1d`](https://docs.scipy.org/
 new_wavelengths = np.linspace(400, 1000, 500)
 
 # Resample spectra
-sf_resampled = sf.resample_wl(new_wavelengths)
+sf_resampled = sf.wl_resample(new_wavelengths)
 
 # With custom interpolation parameters
-sf_resampled = sf.resample_wl(new_wavelengths, 
+sf_resampled = sf.wl_resample(new_wavelengths, 
                              kind='cubic', 
                              bounds_error=False, 
                              fill_value='extrapolate')
@@ -219,7 +219,7 @@ best_matches = sf.query("correlation > 0.95")
 ```python
 # More complex preprocessing pipeline
 processed_sf = (sf
-    .resample_wl(np.linspace(400, 4000, 1000))
+    .wl_resample(np.linspace(400, 4000, 1000))
     .smooth("savgol", window_length=7, polyorder=2)
     .sbaseline("snip", max_half_window=40)
     .normalize("peak", peak_range=(2800, 3000))
@@ -236,4 +236,3 @@ processed_sf = (sf
    - Normalization (for classification or comparison purposes)
 
 **Parameter optimization**: Test different parameters on representative spectra before applying to entire datasets
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.9
 target-version = "py39"
-lint.ignore-init-module-imports = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyspc"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT"
 description = "Tools for Spectroscopy"
 authors = ["Rustam Guliev <glvrst@gmail.com>"]

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -375,6 +375,95 @@ class SpectraFrame:
         return SpectraFrame(spc=self.spc.copy(), wl=self.wl.copy(), data=new_data)
 
     # ----------------------------------------------------------------------
+    # Sorting
+
+    def sort_index(self, *args, **kwargs) -> "SpectraFrame":
+        """Return a new SpectraFrame sorted by row index.
+
+        Mirrors pandas.DataFrame.sort_index for sorting rows, but always returns
+        a new SpectraFrame and keeps spectra aligned with metadata.
+
+        Examples
+        --------
+        >>> sf = SpectraFrame(
+        ...     [[1, 2], [3, 4]],
+        ...     wl=[500, 600],
+        ...     data={"group": ["B", "A"]},
+        ... )
+        >>> sf.data.index = [2, 1]
+        >>> print(sf.sort_index())
+           500  600 group
+        1    3    4     A
+        2    1    2     B
+        """
+        kwargs.pop("inplace", None)
+        axis = kwargs.pop("axis", 0)
+        if axis not in [0, "index"]:
+            raise ValueError("SpectraFrame.sort_index only supports axis=0 (rows).")
+        ignore_index = kwargs.pop("ignore_index", False)
+
+        sorted_data = self.data.sort_index(*args, **kwargs)
+        row_indexer = self.data.index.get_indexer_for(sorted_data.index)
+        new_spc = self.spc[row_indexer, :]
+
+        if ignore_index:
+            sorted_data = sorted_data.reset_index(drop=True)
+
+        return SpectraFrame(spc=new_spc, wl=self.wl.copy(), data=sorted_data)
+
+    def sort_values(self, by, *args, **kwargs) -> "SpectraFrame":
+        """Return a new SpectraFrame sorted by row values.
+
+        Mirrors pandas.DataFrame.sort_values for sorting rows, but always returns
+        a new SpectraFrame and keeps spectra aligned with metadata.
+
+        Examples
+        --------
+        >>> sf = SpectraFrame([[1, 2], [3, 4]], wl=[500, 600], data={"group": ["B", "A"]})
+        >>> print(sf.sort_values("group"))
+           500  600 group
+        1    3    4     A
+        0    1    2     B
+        """
+        kwargs.pop("inplace", None)
+        axis = kwargs.pop("axis", 0)
+        if axis not in [0, "index"]:
+            raise ValueError("SpectraFrame.sort_values only supports axis=0 (rows).")
+        ignore_index = kwargs.pop("ignore_index", False)
+
+        sorted_data = self.data.sort_values(by=by, *args, **kwargs)
+        row_indexer = self.data.index.get_indexer_for(sorted_data.index)
+        new_spc = self.spc[row_indexer, :]
+
+        if ignore_index:
+            sorted_data = sorted_data.reset_index(drop=True)
+
+        return SpectraFrame(spc=new_spc, wl=self.wl.copy(), data=sorted_data)
+
+    def wl_sort(
+        self, ascending: bool = True, kind: str = "quicksort"
+    ) -> "SpectraFrame":
+        """Return a new SpectraFrame with sorted wavelengths.
+
+        The wavelength array is sorted, and columns in `spc` are reordered to
+        stay aligned with the updated wavelength order.
+
+        Examples
+        --------
+        >>> sf = SpectraFrame([[1, 2], [3, 4]], wl=[600, 500], data={"group": ["A", "B"]})
+        >>> print(sf.wl_sort())
+           500  600 group
+        0    2    1     A
+        1    4    3     B
+        """
+        wl_order = np.argsort(self.wl, kind=kind)
+        if not ascending:
+            wl_order = wl_order[::-1]
+        new_wl = self.wl[wl_order]
+        new_spc = self.spc[:, wl_order]
+        return SpectraFrame(spc=new_spc, wl=new_wl, data=self.data.copy())
+
+    # ----------------------------------------------------------------------
     # Copying
 
     def copy(self) -> "SpectraFrame":
@@ -841,7 +930,7 @@ class SpectraFrame:
     # ----------------------------------------------------------------------
     # Wavelengths
 
-    def resample_wl(
+    def wl_resample(
         self, new_wl: np.ndarray, method="interp1d", **kwargs
     ) -> "SpectraFrame":
         """Resample wavelengths, i.e. shift wavelenghts with interpolation
@@ -876,6 +965,20 @@ class SpectraFrame:
             raise NotImplementedError("Other methods not available yet")
 
         return SpectraFrame(new_spc, wl=new_wl, data=self.data)
+
+    def resample_wl(
+        self, new_wl: np.ndarray, method="interp1d", **kwargs
+    ) -> "SpectraFrame":
+        """Resample wavelengths (deprecated name for ``wl_resample``).
+
+        This method is kept for backward compatibility. Use ``wl_resample``.
+        """
+        warnings.warn(
+            "resample_wl is deprecated; use wl_resample instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.wl_resample(new_wl, method=method, **kwargs)
 
     # ----------------------------------------------------------------------
     # Stats & Applys

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -432,6 +432,20 @@ class SpectraFrame:
            500  600 group
         1    3    4     A
         0    1    2     B
+        >>> sf = SpectraFrame(
+        ...     [[1, 2], [3, 4], [5, 6], [7, 8]],
+        ...     wl=[500, 600],
+        ...     data={
+        ...         "group": ["B", "A", "B", "A"],
+        ...         "score": [1, 2, 3, 4],
+        ...     },
+        ... )
+        >>> print(sf.sort_values(["group", "score"], ascending=[True, False]))
+           500  600 group  score
+        3    7    8     A      4
+        1    3    4     A      2
+        2    5    6     B      3
+        0    1    2     B      1
         """
         kwargs.pop("inplace", None)
         axis = kwargs.pop("axis", 0)

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -390,7 +390,7 @@ class SpectraFrame:
         ...     wl=[500, 600],
         ...     data={"group": ["B", "A"]},
         ... )
-        >>> sf.data.index = [2, 1]
+        >>> sf.index = [2, 1]
         >>> print(sf.sort_index())
            500  600 group
         1    3    4     A
@@ -419,7 +419,11 @@ class SpectraFrame:
 
         Examples
         --------
-        >>> sf = SpectraFrame([[1, 2], [3, 4]], wl=[500, 600], data={"group": ["B", "A"]})
+        >>> sf = SpectraFrame(
+        ...     [[1, 2], [3, 4]],
+        ...     wl=[500, 600],
+        ...     data={"group": ["B", "A"]},
+        ... )
         >>> print(sf.sort_values("group"))
            500  600 group
         1    3    4     A
@@ -450,7 +454,11 @@ class SpectraFrame:
 
         Examples
         --------
-        >>> sf = SpectraFrame([[1, 2], [3, 4]], wl=[600, 500], data={"group": ["A", "B"]})
+        >>> sf = SpectraFrame(
+        ...     [[1, 2], [3, 4]],
+        ...     wl=[600, 500],
+        ...     data={"group": ["A", "B"]},
+        ... )
         >>> print(sf.wl_sort())
            500  600 group
         0    2    1     A

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -402,6 +402,7 @@ class SpectraFrame:
             raise ValueError("SpectraFrame.sort_index only supports axis=0 (rows).")
         ignore_index = kwargs.pop("ignore_index", False)
 
+        # Track original row positions to keep alignment with duplicate indices.
         sorted_data = self.data.assign(_pos=np.arange(len(self.data))).sort_index(
             *args, **kwargs
         )
@@ -438,6 +439,7 @@ class SpectraFrame:
             raise ValueError("SpectraFrame.sort_values only supports axis=0 (rows).")
         ignore_index = kwargs.pop("ignore_index", False)
 
+        # Track original row positions to keep alignment with duplicate indices.
         sorted_data = self.data.assign(_pos=np.arange(len(self.data))).sort_values(
             by=by, *args, **kwargs
         )

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -402,9 +402,12 @@ class SpectraFrame:
             raise ValueError("SpectraFrame.sort_index only supports axis=0 (rows).")
         ignore_index = kwargs.pop("ignore_index", False)
 
-        sorted_data = self.data.sort_index(*args, **kwargs)
-        row_indexer = self.data.index.get_indexer_for(sorted_data.index)
+        sorted_data = self.data.assign(_pos=np.arange(len(self.data))).sort_index(
+            *args, **kwargs
+        )
+        row_indexer = sorted_data["_pos"].to_numpy()
         new_spc = self.spc[row_indexer, :]
+        sorted_data = sorted_data.drop(columns="_pos")
 
         if ignore_index:
             sorted_data = sorted_data.reset_index(drop=True)
@@ -435,9 +438,12 @@ class SpectraFrame:
             raise ValueError("SpectraFrame.sort_values only supports axis=0 (rows).")
         ignore_index = kwargs.pop("ignore_index", False)
 
-        sorted_data = self.data.sort_values(by=by, *args, **kwargs)
-        row_indexer = self.data.index.get_indexer_for(sorted_data.index)
+        sorted_data = self.data.assign(_pos=np.arange(len(self.data))).sort_values(
+            by=by, *args, **kwargs
+        )
+        row_indexer = sorted_data["_pos"].to_numpy()
         new_spc = self.spc[row_indexer, :]
+        sorted_data = sorted_data.drop(columns="_pos")
 
         if ignore_index:
             sorted_data = sorted_data.reset_index(drop=True)

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -220,6 +220,33 @@ class TestSpectraFrameSorting:
             pd.DataFrame({"group": ["d", "c", "b", "a"]}, index=[0, 0, 1, 1]),
         )
 
+    def test_sort_index_ascending_param(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6]])
+        data = pd.DataFrame({"group": ["b", "a", "c"]}, index=[2, 0, 1])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_index(ascending=False)
+
+        assert_index_equal(sorted_sf.index, pd.Index([2, 1, 0]))
+        assert_array_equal(sorted_sf.spc, np.array([[1, 2], [5, 6], [3, 4]]))
+        assert_frame_equal(
+            sorted_sf.data, pd.DataFrame({"group": ["b", "c", "a"]}, index=[2, 1, 0])
+        )
+
+    def test_sort_index_na_position(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6]])
+        data = pd.DataFrame({"group": ["b", "missing", "a"]}, index=[1, np.nan, 0])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_index(na_position="first")
+
+        assert_index_equal(sorted_sf.index, pd.Index([np.nan, 0, 1]))
+        assert_array_equal(sorted_sf.spc, np.array([[3, 4], [5, 6], [1, 2]]))
+        assert_frame_equal(
+            sorted_sf.data,
+            pd.DataFrame({"group": ["missing", "a", "b"]}, index=[np.nan, 0, 1]),
+        )
+
     def test_sort_values(self):
         spc = np.array([[1, 2], [3, 4], [5, 6]])
         data = pd.DataFrame({"group": ["b", "a", "c"]})

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -214,7 +214,9 @@ class TestSpectraFrameSorting:
         sorted_sf = sf.sort_values("group")
 
         assert_array_equal(sorted_sf.spc, np.array([[3, 4], [1, 2], [5, 6]]))
-        assert_frame_equal(sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]}))
+        assert_frame_equal(
+            sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]}, index=[1, 0, 2])
+        )
 
     def test_wl_sort(self):
         spc = np.array([[1, 2, 3], [4, 5, 6]])

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 from pandas.testing import assert_frame_equal, assert_series_equal, assert_index_equal
 import pytest
 from pathlib import Path
@@ -190,6 +190,68 @@ class TestSpectraFrameCopy:
         assert copied.spc is not sf.spc
         assert copied.wl is not sf.wl
         assert copied.data is not sf.data
+
+
+class TestSpectraFrameSorting:
+    def test_sort_index(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6]])
+        data = pd.DataFrame({"group": ["b", "a", "c"]}, index=[2, 0, 1])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_index()
+
+        assert_index_equal(sorted_sf.index, pd.Index([0, 1, 2]))
+        assert_array_equal(sorted_sf.spc, np.array([[3, 4], [5, 6], [1, 2]]))
+        assert_frame_equal(
+            sorted_sf.data, pd.DataFrame({"group": ["a", "c", "b"]}, index=[0, 1, 2])
+        )
+
+    def test_sort_values(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6]])
+        data = pd.DataFrame({"group": ["b", "a", "c"]})
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_values("group")
+
+        assert_array_equal(sorted_sf.spc, np.array([[3, 4], [1, 2], [5, 6]]))
+        assert_frame_equal(
+            sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]})
+        )
+
+    def test_wl_sort(self):
+        spc = np.array([[1, 2, 3], [4, 5, 6]])
+        wl = [600, 500, 700]
+        sf = SpectraFrame(spc, wl=wl)
+
+        sorted_sf = sf.wl_sort()
+
+        assert_array_equal(sorted_sf.wl, np.array([500, 600, 700]))
+        assert_array_equal(sorted_sf.spc, np.array([[2, 1, 3], [5, 4, 6]]))
+
+    def test_resample_wl_deprecated_alias(self):
+        spc = np.array([[1.0, 2.0, 3.0]])
+        wl = np.array([400.0, 500.0, 600.0])
+        sf = SpectraFrame(spc, wl=wl)
+        new_wl = np.array([450.0, 550.0])
+
+        with pytest.warns(DeprecationWarning, match="resample_wl is deprecated"):
+            resampled = sf.resample_wl(new_wl)
+
+        expected = sf.wl_resample(new_wl)
+        assert_array_equal(resampled.wl, expected.wl)
+        assert_allclose(resampled.spc, expected.spc)
+
+    def test_wl_resample(self):
+        spc = np.array([[0.0, 10.0, 20.0]])
+        wl = np.array([0.0, 1.0, 2.0])
+        sf = SpectraFrame(spc, wl=wl)
+        new_wl = np.array([0.0, 0.5, 1.5, 2.0])
+
+        resampled = sf.wl_resample(new_wl)
+
+        expected_spc = np.array([[0.0, 5.0, 15.0, 20.0]])
+        assert_array_equal(resampled.wl, new_wl)
+        assert_allclose(resampled.spc, expected_spc)
 
 
 class TestSpectraFrameItems:

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -214,9 +214,7 @@ class TestSpectraFrameSorting:
         sorted_sf = sf.sort_values("group")
 
         assert_array_equal(sorted_sf.spc, np.array([[3, 4], [1, 2], [5, 6]]))
-        assert_frame_equal(
-            sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]})
-        )
+        assert_frame_equal(sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]}))
 
     def test_wl_sort(self):
         spc = np.array([[1, 2, 3], [4, 5, 6]])

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -246,6 +246,39 @@ class TestSpectraFrameSorting:
             pd.DataFrame({"group": ["a", "a", "b", "b"]}, index=[1, 0, 1, 0]),
         )
 
+    def test_sort_values_ascending_param(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        data = pd.DataFrame(
+            {"group": ["b", "a", "b", "a"], "score": [1, 2, 3, 4]}, index=[1, 1, 0, 0]
+        )
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_values(["group", "score"], ascending=[True, False])
+
+        assert_index_equal(sorted_sf.index, pd.Index([0, 1, 0, 1]))
+        assert_array_equal(sorted_sf.spc, np.array([[7, 8], [3, 4], [5, 6], [1, 2]]))
+        assert_frame_equal(
+            sorted_sf.data,
+            pd.DataFrame(
+                {"group": ["a", "a", "b", "b"], "score": [4, 2, 3, 1]},
+                index=[0, 1, 0, 1],
+            ),
+        )
+
+    def test_sort_values_na_position(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6]])
+        data = pd.DataFrame({"group": ["b", None, "a"]}, index=[2, 1, 0])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_values("group", na_position="first")
+
+        assert_index_equal(sorted_sf.index, pd.Index([1, 0, 2]))
+        assert_array_equal(sorted_sf.spc, np.array([[3, 4], [5, 6], [1, 2]]))
+        assert_frame_equal(
+            sorted_sf.data,
+            pd.DataFrame({"group": [None, "a", "b"]}, index=[1, 0, 2]),
+        )
+
     def test_wl_sort(self):
         spc = np.array([[1, 2, 3], [4, 5, 6]])
         wl = [600, 500, 700]

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -206,6 +206,20 @@ class TestSpectraFrameSorting:
             sorted_sf.data, pd.DataFrame({"group": ["a", "c", "b"]}, index=[0, 1, 2])
         )
 
+    def test_sort_index_duplicate_indices(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        data = pd.DataFrame({"group": ["b", "a", "d", "c"]}, index=[1, 1, 0, 0])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_index()
+
+        assert_index_equal(sorted_sf.index, pd.Index([0, 0, 1, 1]))
+        assert_array_equal(sorted_sf.spc, np.array([[5, 6], [7, 8], [1, 2], [3, 4]]))
+        assert_frame_equal(
+            sorted_sf.data,
+            pd.DataFrame({"group": ["d", "c", "b", "a"]}, index=[0, 0, 1, 1]),
+        )
+
     def test_sort_values(self):
         spc = np.array([[1, 2], [3, 4], [5, 6]])
         data = pd.DataFrame({"group": ["b", "a", "c"]})
@@ -216,6 +230,20 @@ class TestSpectraFrameSorting:
         assert_array_equal(sorted_sf.spc, np.array([[3, 4], [1, 2], [5, 6]]))
         assert_frame_equal(
             sorted_sf.data, pd.DataFrame({"group": ["a", "b", "c"]}, index=[1, 0, 2])
+        )
+
+    def test_sort_values_duplicate_indices(self):
+        spc = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        data = pd.DataFrame({"group": ["b", "a", "a", "b"]}, index=[1, 1, 0, 0])
+        sf = SpectraFrame(spc, wl=[500, 600], data=data)
+
+        sorted_sf = sf.sort_values("group")
+
+        assert_index_equal(sorted_sf.index, pd.Index([1, 0, 1, 0]))
+        assert_array_equal(sorted_sf.spc, np.array([[3, 4], [5, 6], [1, 2], [7, 8]]))
+        assert_frame_equal(
+            sorted_sf.data,
+            pd.DataFrame({"group": ["a", "a", "b", "b"]}, index=[1, 0, 1, 0]),
         )
 
     def test_wl_sort(self):


### PR DESCRIPTION
### Motivation

- Make the Sorting documentation appear in a more logical place after metadata manipulation. 
- Ensure documentation examples use the standardized `wl_resample` API rather than the deprecated name. 
- Add unit coverage for the `wl_resample` interpolation behavior and wavelength alignment.

### Description

- Moved the `## Sorting` section in `docs/user-guide/manipulation.md` to follow metadata manipulation and added short examples using `sort_index`, `sort_values`, and `wl_sort`.
- Replaced documented usages of the old name with `wl_resample` in `docs/user-guide/preprocessing.md` and the concatenation example in `manipulation.md`.
- Added `TestSpectraFrameSorting` tests to `tests/test_spectra.py` covering `sort_index`, `sort_values`, `wl_sort`, the deprecated `resample_wl` alias, and a new `test_wl_resample` that asserts interpolation output and wavelength alignment; also added `assert_allclose` import used by the new test.

### Testing

- Added unit tests in `tests/test_spectra.py` for sorting and `wl_resample` behavior, including `test_wl_resample` and `test_resample_wl_deprecated_alias`.
- Automated tests were not executed as part of this change (no `pytest` run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7c8984148332a7d72e27ae514e04)