### PR TITLE
Refactor baseline threading helper and centralize baseline selection

### DIFF
--- a/docs/user-guide/manipulation.md
+++ b/docs/user-guide/manipulation.md
@@ -96,6 +96,21 @@ from scipy import ndimage
 second_deriv = sf.apply(lambda x: ndimage.gaussian_filter1d(x, sigma=1, order=2), axis=1)
 ```
 
+## Baseline Estimation
+
+Baseline estimation uses the `pybaselines` algorithms via `SpectraFrame.baseline`.
+By default, baseline computation is single-threaded for maximum compatibility. If you
+are running on a free-threaded Python build (or know your environment can benefit),
+set `single_threaded=False` to use multithreading for the per-spectrum computations.
+
+```python
+# Single-threaded (default)
+baseline = sf.baseline("arpls")
+
+# Multi-threaded (experimental; requires thread-safe environment)
+baseline_threaded = sf.baseline("arpls", single_threaded=False)
+```
+
 ## Metadata Manipulation
 
 ### Adding and Removing Columns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyspc"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 description = "Tools for Spectroscopy"
 authors = ["Rustam Guliev <glvrst@gmail.com>"]

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -1,6 +1,9 @@
 import os
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Optional, Union, Tuple, Callable, TypeVar
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
+from multiprocessing import get_context
+from typing import Any, Optional, Union, Tuple, Callable, TypeVar, Literal
 from pathlib import Path
 import warnings
 import re
@@ -20,6 +23,28 @@ from .peaks import around_max_peak_fit
 __all__ = ["SpectraFrame"]
 
 PathLike = TypeVar("PathLike", str, os.PathLike)
+StartMethod = Literal["fork", "spawn", "forkserver"]
+
+_NUMPY_VECTORIZABLE_APPLY_FUNCTIONS = frozenset(
+    {
+        "amin",
+        "amax",
+        "min",
+        "max",
+        "sum",
+        "mean",
+        "std",
+        "median",
+        "quantile",
+        "nanmin",
+        "nanmax",
+        "nansum",
+        "nanmean",
+        "nanstd",
+        "nanmedian",
+        "nanquantile",
+    }
+)
 
 
 def _require_einops():
@@ -54,22 +79,68 @@ def _einops_pattern_to_names(pattern: str) -> list[str]:
     return names
 
 
-def _thread_baseline_func(
+def _baseline_func(
     wl: np.ndarray,
     method: str,
     kwargs: dict[str, Any],
 ) -> Callable[[np.ndarray], np.ndarray]:
-    """Create a baseline function for use within a single thread."""
-    if method == "rubberband":
-        return lambda y: rubberband(wl, y, **kwargs)
+    """Create a baseline function with captured x-values and method settings."""
 
     baseline_fitter = pybaselines.Baseline(x_data=wl)
-    if not hasattr(baseline_fitter, method):
-        raise ValueError(
-            "Unknown method. Method must be either " "from `pybaselines` or 'rubberband'"
-        )
-    baseline_method = getattr(baseline_fitter, method)
-    return lambda y: baseline_method(y, **kwargs)[0]
+    baseline_method = _baseline_method_from_fitter(
+        baseline_fitter, wl=wl, method=method
+    )
+    return lambda y: baseline_method(y, kwargs)
+
+
+def _apply_callable_worker(
+    y: np.ndarray,
+    *,
+    func: Callable,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Run a generic row-wise callable in a process worker."""
+
+    return func(y, *args, **kwargs)
+
+
+def _baseline_worker(
+    y: np.ndarray,
+    *,
+    wl: np.ndarray,
+    method: str,
+    kwargs: dict[str, Any],
+) -> np.ndarray:
+    """Compute baseline for a single spectrum in a pickle-friendly way."""
+
+    # Create the fitter inside the worker to avoid pickling non-serializable objects.
+    baseline_fitter = pybaselines.Baseline(x_data=wl)
+    baseline_method = _baseline_method_from_fitter(
+        baseline_fitter, wl=wl, method=method
+    )
+    return baseline_method(y, kwargs)
+
+
+def _baseline_method_from_fitter(
+    baseline_fitter: pybaselines.Baseline,
+    *,
+    wl: np.ndarray,
+    method: str,
+) -> Callable[[np.ndarray, dict[str, Any]], np.ndarray]:
+    """Resolve the baseline callable given a configured baseline fitter."""
+
+    # Prefer `pybaselines` methods when available; otherwise use the built-in fallback.
+    if hasattr(baseline_fitter, method):
+        baseline_method = getattr(baseline_fitter, method)
+        return lambda y, kwargs: baseline_method(y, **kwargs)[0]
+
+    if method == "rubberband":
+        return lambda y, kwargs: rubberband(wl, y, **kwargs)
+
+    raise ValueError(
+        "Unknown method. Method must be either from `pybaselines` or 'rubberband'"
+    )
 
 
 def _sorted_unique(values: pd.Series) -> list[Any]:
@@ -1106,69 +1177,247 @@ class SpectraFrame:
 
         return groupby
 
-    def _apply_func(
-        self,
-        func: Union[str, Callable],
-        *args,
-        data: Optional[np.ndarray] = None,
-        axis: int = 1,
-        **kwargs,
-    ) -> np.ndarray:
-        """Apply a function alog an axis
-
-        Dispatches calculation to `np.apply_alog_axis` (if func is callable) or
-        `np.<func>` (if func is a string)
-
-        Parameters
-        ----------
-        func : Union[str, Callable]
-            Either a string with the name of numpy funciton, e.g "max", "mean", etc.
-            Or a callable function that can be passed to `numpy.apply_along_axis`
-        data : np.ndarray, optional
-            To which data apply the function, by default `self.spc`
-            This parameter is useful for cases when the function must be applied on
-            different parts of the spctral data, e.g. when groupby is used
-        axis : int, optional
-            Standard axis. Same as in `numpy` or `pandas`, by default 1
-
-        Returns
-        -------
-        np.ndarray
-            The output array. The shape of out is identical to the shape of data, except
-            along the axis dimension. This axis is removed, and replaced with new
-            dimensions equal to the shape of the return value of func. So if func
-            returns a scalar, the output will be eirther single row (axis=0) or
-            single column (axis=1) matrix.
-
-        Raises
-        ------
-        ValueError
-            Function with provided name `func` was not found in `numpy`
-        """
-        # Check and prepare parameters
-        if data is None:
-            data = self.spc
+    def _classify_apply_func(
+        self, func: Union[str, Callable]
+    ) -> Tuple[Literal["numpy_vectorized", "callable_generic"], Callable]:
+        """Classify and normalize an apply function."""
 
         if isinstance(func, str):
-            name = func
-            if hasattr(np, name):
-                func = getattr(np, name)
+            if not hasattr(np, func):
+                raise ValueError(f"Could not find function {func} in `numpy`")
+            return "numpy_vectorized", getattr(np, func)
+
+        if not callable(func):
+            raise TypeError("`func` must be either a string or a callable")
+
+        # Prefer NumPy vectorized implementations when a matching callable is provided.
+        func_name = getattr(func, "__name__", "")
+        func_module = getattr(func, "__module__", "")
+        if (
+            func_module.startswith("numpy")
+            and (func_name in _NUMPY_VECTORIZABLE_APPLY_FUNCTIONS)
+            and hasattr(np, func_name)
+        ):
+            return "numpy_vectorized", getattr(np, func_name)
+
+        return "callable_generic", func
+
+    def _reshape_apply_result(self, result: np.ndarray, axis: int) -> np.ndarray:
+        """Normalize apply output shape to 2D spectral matrix."""
+
+        if result.ndim == 1:
+            result = result.reshape((1, -1)) if axis == 0 else result.reshape((-1, 1))
+
+        if result.ndim != 2:
+            raise ValueError(
+                "Applied function must return a scalar or a 1D array for each slice."
+            )
+
+        return result
+
+    def _apply_numpy_vectorized(
+        self,
+        func: Callable,
+        *args,
+        data: np.ndarray,
+        axis: int,
+        **kwargs,
+    ) -> np.ndarray:
+        """Apply a NumPy vectorized function."""
+
+        result = np.asarray(func(data, *args, axis=axis, **kwargs))
+
+        # Functions like np.quantile return dimensions in a different order.
+        if (result.ndim > 1) and (axis == 1):
+            result = result.T
+
+        return self._reshape_apply_result(result, axis=axis)
+
+    def _apply_callable_serial(
+        self,
+        func: Callable,
+        *args,
+        data: np.ndarray,
+        axis: int,
+        **kwargs,
+    ) -> np.ndarray:
+        """Apply a generic callable using numpy.apply_along_axis."""
+
+        result = np.apply_along_axis(func, axis, data, *args, **kwargs)
+        return self._reshape_apply_result(np.asarray(result), axis=axis)
+
+    def _stack_parallel_apply_outputs(self, outputs: list[Any]) -> np.ndarray:
+        """Validate and stack row-wise outputs from worker processes."""
+
+        if len(outputs) == 0:
+            raise ValueError("Cannot apply function to empty spectral data.")
+
+        normalized = [np.asarray(out) for out in outputs]
+        first_shape = normalized[0].shape
+        for out in normalized[1:]:
+            if out.shape != first_shape:
+                raise ValueError(
+                    "Parallel apply requires a consistent output shape for every row."
+                )
+
+        if normalized[0].ndim == 0:
+            scalar_result = np.asarray(normalized)
+            return self._reshape_apply_result(scalar_result, axis=1)
+
+        stacked_result = np.stack(normalized, axis=0)
+        return self._reshape_apply_result(stacked_result, axis=1)
+
+    def _apply_callable_parallel_rows(
+        self,
+        func: Callable,
+        *args,
+        data: np.ndarray,
+        max_workers: Optional[int],
+        start_method: Optional[StartMethod],
+        chunksize: Optional[int],
+        **kwargs,
+    ) -> np.ndarray:
+        """Apply a generic callable row-wise in worker processes."""
+
+        worker_func = partial(
+            _apply_callable_worker,
+            func=func,
+            args=args,
+            kwargs=kwargs,
+        )
+
+        # Validate pickling before starting worker processes.
+        try:
+            pickle.dumps(worker_func)
+        except Exception as e:
+            raise ValueError(
+                "Parallel apply requires a pickleable callable and arguments."
+            ) from e
+
+        with ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=get_context(start_method) if start_method is not None else None,
+        ) as pool:
+            if chunksize is None:
+                outputs = list(pool.map(worker_func, data))
             else:
-                raise ValueError(f"Could not find function {name} in `numpy`")
+                outputs = list(pool.map(worker_func, data, chunksize=chunksize))
 
-            res: np.ndarray = func(data, *args, axis=axis, **kwargs)
-            # Functions like np.quantile behave differently than apply_alog_axis
-            # Here we make the shape of the matrix to be the same
-            if (res.ndim > 1) and (axis == 1):
-                res = res.T
-        else:
-            res = np.apply_along_axis(func, axis, data, *args, **kwargs)
+        return self._stack_parallel_apply_outputs(outputs)
 
-        # Reshape the result to keep dimenstions
-        if res.ndim == 1:
-            res = res.reshape((1, -1)) if axis == 0 else res.reshape((-1, 1))
+    def _validate_parallel_apply(
+        self,
+        *,
+        parallel: bool,
+        func_kind: Literal["numpy_vectorized", "callable_generic"],
+        axis: int,
+        groupby: Union[list[str], None],
+        chunksize: Optional[int],
+    ) -> None:
+        """Validate parallel apply strategy and options."""
 
-        return res
+        if (chunksize is not None) and (chunksize < 1):
+            raise ValueError("`chunksize` must be >= 1")
+
+        if not parallel:
+            return
+
+        if groupby is not None:
+            raise ValueError("`parallel=True` does not support `groupby`.")
+
+        if func_kind == "numpy_vectorized":
+            raise ValueError(
+                "`parallel=True` is only supported for non-vectorized callables."
+            )
+
+        if axis != 1:
+            raise ValueError("`parallel=True` currently supports only `axis=1`.")
+
+    def _apply_dispatch(
+        self,
+        func: Callable,
+        *args,
+        data: np.ndarray,
+        axis: int,
+        parallel: bool,
+        func_kind: Literal["numpy_vectorized", "callable_generic"],
+        max_workers: Optional[int],
+        start_method: Optional[StartMethod],
+        chunksize: Optional[int],
+        **kwargs,
+    ) -> np.ndarray:
+        """Dispatch apply execution to vectorized, serial, or parallel path."""
+
+        if func_kind == "numpy_vectorized":
+            return self._apply_numpy_vectorized(
+                func,
+                *args,
+                data=data,
+                axis=axis,
+                **kwargs,
+            )
+
+        if parallel:
+            return self._apply_callable_parallel_rows(
+                func,
+                *args,
+                data=data,
+                max_workers=max_workers,
+                start_method=start_method,
+                chunksize=chunksize,
+                **kwargs,
+            )
+
+        return self._apply_callable_serial(
+            func,
+            *args,
+            data=data,
+            axis=axis,
+            **kwargs,
+        )
+
+    def _apply_grouped(
+        self,
+        func: Callable,
+        *args,
+        groupby: list[str],
+        func_kind: Literal["numpy_vectorized", "callable_generic"],
+        **kwargs,
+    ) -> Tuple[np.ndarray, pd.DataFrame]:
+        """Apply function per group and combine outputs."""
+
+        grouped = self.to_pandas().groupby(groupby, observed=True)[self.wl]
+
+        spc_list: list[np.ndarray] = []
+        data_list: list[pd.DataFrame] = []
+        for key, group in grouped:
+            # Normalize group keys for both 1-column and multi-column groupby.
+            key_values = key if isinstance(key, tuple) else (key,)
+            group_values = dict(zip(groupby, key_values))
+
+            group_result = self._apply_dispatch(
+                func,
+                *args,
+                data=group.values,
+                axis=0,
+                parallel=False,
+                func_kind=func_kind,
+                max_workers=None,
+                start_method=None,
+                chunksize=None,
+                **kwargs,
+            )
+            spc_list.append(group_result)
+            data_list.append(
+                pd.DataFrame(
+                    {**group_values, "group_index": range(group_result.shape[0])}
+                )
+            )
+
+        return (
+            np.concatenate(spc_list, axis=0),
+            pd.concat(data_list, axis=0, ignore_index=True),
+        )
 
     def apply(
         self,
@@ -1176,6 +1425,10 @@ class SpectraFrame:
         *args,
         groupby: Union[str, list[str], None] = None,
         axis: int = 0,
+        parallel: bool = False,
+        max_workers: Optional[int] = None,
+        start_method: Optional[StartMethod] = None,
+        chunksize: Optional[int] = None,
         **kwargs,
     ) -> "SpectraFrame":
         """Apply function to the spectral data
@@ -1191,6 +1444,16 @@ class SpectraFrame:
         axis : int, optional
              Standard axis. Same as in `numpy` or `pandas`, by default 1 when groupby
              is not provided, and 0 when provided.
+        parallel : bool, optional
+            If True, apply callables with process-based parallelism. Supported only
+            for callables that are not NumPy-vectorized, with `axis=1` and no
+            `groupby`.
+        max_workers : int, optional
+            Maximum number of worker processes for parallel mode.
+        start_method : {"fork", "spawn", "forkserver"}, optional
+            Process start method for multiprocessing context in parallel mode.
+        chunksize : int, optional
+            Chunk size for `ProcessPoolExecutor.map` in parallel mode.
 
         Returns
         -------
@@ -1206,34 +1469,40 @@ class SpectraFrame:
         # Prepare arguments
         axis = self._get_axis(axis, groupby)
         groupby = self._get_groupby(groupby)
+        func_kind, resolved_func = self._classify_apply_func(func)
+        self._validate_parallel_apply(
+            parallel=parallel,
+            func_kind=func_kind,
+            axis=axis,
+            groupby=groupby,
+            chunksize=chunksize,
+        )
 
         # Prepare default values
         new_wl = self.wl if axis == 0 else None
         new_data = self.data if axis == 1 else None
 
         if groupby is None:
-            new_spc = self._apply_func(func, *args, axis=axis, **kwargs)
+            new_spc = self._apply_dispatch(
+                resolved_func,
+                *args,
+                data=self.spc,
+                axis=axis,
+                parallel=parallel,
+                func_kind=func_kind,
+                max_workers=max_workers,
+                start_method=start_method,
+                chunksize=chunksize,
+                **kwargs,
+            )
         else:
-            # Prepare a dataframe for groupby aggregation
-            grouped = self.to_pandas().groupby(groupby, observed=True)[self.wl]
-
-            # Prepare list of group names as dicts {'column name': 'column value', ...}
-            keys = [i for i, _ in grouped]
-            groups = [dict(zip(groupby, gr)) for gr in keys]
-
-            # Apply to each group
-            spc_list = [
-                self._apply_func(func, *args, data=group.values, axis=0, **kwargs)
-                for _, group in grouped
-            ]
-            data_list = [
-                pd.DataFrame({**gr, "group_index": range(spc_list[i].shape[0])})
-                for i, gr in enumerate(groups)
-            ]
-
-            # Combine
-            new_spc = np.concatenate(spc_list, axis=0)
-            new_data = pd.concat(data_list, axis=0, ignore_index=True)
+            new_spc, new_data = self._apply_grouped(
+                resolved_func,
+                *args,
+                groupby=groupby,
+                func_kind=func_kind,
+                **kwargs,
+            )
 
         # If the applied function returns same number of wavelenghts
         # we assume that wavelengths are the same, e.g. baseline,
@@ -1964,7 +2233,10 @@ class SpectraFrame:
         self,
         method: str,
         *,
-        single_threaded: bool = True,
+        parallel: bool = False,
+        max_workers: Optional[int] = None,
+        start_method: Optional[StartMethod] = None,
+        chunksize: Optional[int] = None,
         **kwargs,
     ) -> "SpectraFrame":
         """Dispatcher for spectra baseline estimation
@@ -1978,10 +2250,16 @@ class SpectraFrame:
         method : str
             A name of the method in `pybaselines` package (e.g. "airpls", "snip"),
             or "rubberband"
-        single_threaded : bool, optional
-            If True, uses the classic single-threaded baseline computation. If False,
-            uses multithreading for baseline estimation by fitting each spectrum in
-            a thread.
+        parallel : bool, optional
+            If True, apply baseline estimation per spectrum in parallel using
+            `SpectraFrame.apply(..., parallel=True)`.
+        max_workers : int, optional
+            Maximum number of worker processes.
+        start_method : {"fork", "spawn", "forkserver"}, optional
+            Process start method for multiprocessing context. Forced to "spawn"
+            when method is "loess".
+        chunksize : int, optional
+            Chunk size for worker scheduling in parallel mode.
         kwargs: dict
             Additional parameters to pass to the baseline correction method
 
@@ -1995,19 +2273,32 @@ class SpectraFrame:
         ValueError
             Unknown baseline method provided
         """
-        if single_threaded:
-            baseline_func = _thread_baseline_func(self.wl, method, kwargs)
-            return self.apply(baseline_func, axis=1)
 
-        def thread_baseline_func(y: np.ndarray) -> np.ndarray:
-            baseline_func = _thread_baseline_func(self.wl, method, kwargs)
-            return baseline_func(y)
+        if parallel and (method == "loess"):
+            if (start_method is not None) and (start_method != "spawn"):
+                warnings.warn(
+                    "Overriding 'start_method' to 'spawn' for 'loess' baseline method\n"
+                    "More details here: https://pybaselines.readthedocs.io/en/latest/performance.html#parallel-processing"
+                )
+            start_method = "spawn"
 
-        baselines = np.empty_like(self.spc)
-        with ThreadPoolExecutor() as pool:
-            for index, baseline in enumerate(pool.map(thread_baseline_func, self.spc)):
-                baselines[index] = baseline
-        return SpectraFrame(baselines, wl=self.wl, data=self.data)
+        if parallel:
+            baseline_func = partial(
+                _baseline_worker,
+                wl=self.wl,
+                method=method,
+                kwargs=kwargs,
+            )
+        else:
+            baseline_func = _baseline_func(self.wl, method, kwargs)
+        return self.apply(
+            baseline_func,
+            axis=1,
+            parallel=parallel,
+            max_workers=max_workers,
+            start_method=start_method,
+            chunksize=chunksize,
+        )
 
     def sbaseline(self, method: str, **kwargs) -> "SpectraFrame":
         """Subtract baseline from the spectra

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, Union, Tuple, Callable, TypeVar
 from pathlib import Path
 import warnings
@@ -51,6 +52,24 @@ def _einops_pattern_to_names(pattern: str) -> list[str]:
     names = [tok for tok in pattern.strip().split(" ") if tok]
 
     return names
+
+
+def _thread_baseline_func(
+    wl: np.ndarray,
+    method: str,
+    kwargs: dict[str, Any],
+) -> Callable[[np.ndarray], np.ndarray]:
+    """Create a baseline function for use within a single thread."""
+    if method == "rubberband":
+        return lambda y: rubberband(wl, y, **kwargs)
+
+    baseline_fitter = pybaselines.Baseline(x_data=wl)
+    if not hasattr(baseline_fitter, method):
+        raise ValueError(
+            "Unknown method. Method must be either " "from `pybaselines` or 'rubberband'"
+        )
+    baseline_method = getattr(baseline_fitter, method)
+    return lambda y: baseline_method(y, **kwargs)[0]
 
 
 def _sorted_unique(values: pd.Series) -> list[Any]:
@@ -1941,7 +1960,13 @@ class SpectraFrame:
 
         return spc
 
-    def baseline(self, method: str, **kwargs) -> "SpectraFrame":
+    def baseline(
+        self,
+        method: str,
+        *,
+        single_threaded: bool = True,
+        **kwargs,
+    ) -> "SpectraFrame":
         """Dispatcher for spectra baseline estimation
 
         Dispatches baseline correction to the corresponding method
@@ -1953,6 +1978,10 @@ class SpectraFrame:
         method : str
             A name of the method in `pybaselines` package (e.g. "airpls", "snip"),
             or "rubberband"
+        single_threaded : bool, optional
+            If True, uses the classic single-threaded baseline computation. If False,
+            uses multithreading for baseline estimation by fitting each spectrum in
+            a thread.
         kwargs: dict
             Additional parameters to pass to the baseline correction method
 
@@ -1966,18 +1995,19 @@ class SpectraFrame:
         ValueError
             Unknown baseline method provided
         """
-        baseline_fitter = pybaselines.Baseline(x_data=self.wl)
-        if hasattr(baseline_fitter, method):
-            baseline_method = getattr(baseline_fitter, method)
-            baseline_func = lambda y: baseline_method(y, **kwargs)[0]
-        elif method == "rubberband":
-            baseline_func = lambda y: rubberband(self.wl, y, **kwargs)
-        else:
-            raise ValueError(
-                "Unknown method. Method must be either "
-                "from `pybaselines` or 'rubberband'"
-            )
-        return self.apply(baseline_func, axis=1)
+        if single_threaded:
+            baseline_func = _thread_baseline_func(self.wl, method, kwargs)
+            return self.apply(baseline_func, axis=1)
+
+        def thread_baseline_func(y: np.ndarray) -> np.ndarray:
+            baseline_func = _thread_baseline_func(self.wl, method, kwargs)
+            return baseline_func(y)
+
+        baselines = np.empty_like(self.spc)
+        with ThreadPoolExecutor() as pool:
+            for index, baseline in enumerate(pool.map(thread_baseline_func, self.spc)):
+                baselines[index] = baseline
+        return SpectraFrame(baselines, wl=self.wl, data=self.data)
 
     def sbaseline(self, method: str, **kwargs) -> "SpectraFrame":
         """Subtract baseline from the spectra

--- a/pyspc/spectra.py
+++ b/pyspc/spectra.py
@@ -2424,7 +2424,7 @@ class SpectraFrame:
         assert isinstance(palette, list)
         cmap = dict(zip(colorby_series.cat.categories, palette[:ncolors]))
         cmap.update({"NA": "gray"})
-        colors_series = colorby_series.cat.rename_categories(cmap)
+        colors_series = colorby_series.astype(object).map(cmap).fillna("gray")
 
         # Get the figure and the axes for plot
         if fig is None:
@@ -2441,7 +2441,8 @@ class SpectraFrame:
 
         # Prepare legend lines if needed
         legend_lines = [
-            Line2D([0], [0], color=c, lw=4) for c in colors_series.cat.categories
+            Line2D([0], [0], color=cmap[category], lw=4)
+            for category in colorby_series.cat.categories
         ]
 
         # For each combination of row and column categories

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,81 @@
+import numpy as np
+from pandas.testing import assert_frame_equal
+import pytest
+
+from pyspc import SpectraFrame
+
+
+def _row_minmax(x: np.ndarray) -> np.ndarray:
+    return np.array([np.min(x), np.max(x)])
+
+
+def _row_sum(x: np.ndarray) -> float:
+    return float(np.sum(x))
+
+
+def test_baseline_parallel_matches_serial():
+    wl = 400 + np.arange(0, 10, 2)
+    signal = np.array([0, 5, 10, 5, 0])
+    bl = 10 + 5 * (wl - 400)
+    spc = np.tile(signal + bl, (100, 1))
+    sf = SpectraFrame(spc, wl=wl)
+    expected = sf.baseline("rubberband")
+
+    try:
+        result = sf.baseline(
+            "rubberband",
+            parallel=True,
+            max_workers=2,
+        )
+    except (PermissionError, OSError) as e:
+        pytest.skip(f"ProcessPoolExecutor is not available: {e}")
+    assert np.array_equal(result.spc, expected.spc)
+    assert np.array_equal(result.spc[0, :], bl)
+
+
+def test_apply_parallel_matches_serial_for_callable():
+    sf = SpectraFrame(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        wl=np.array([400.0, 500.0, 600.0]),
+        data={"group": ["A", "A", "B"]},
+    )
+    expected = sf.apply(_row_minmax, axis=1)
+
+    try:
+        result = sf.apply(_row_minmax, axis=1, parallel=True, max_workers=2)
+    except (PermissionError, OSError) as e:
+        pytest.skip(f"ProcessPoolExecutor is not available: {e}")
+
+    assert np.array_equal(result.spc, expected.spc)
+    assert np.array_equal(result.wl, expected.wl)
+    assert_frame_equal(result.data, expected.data)
+
+
+def test_apply_parallel_rejects_numpy_vectorized_function():
+    sf = SpectraFrame(np.arange(12).reshape(3, 4))
+    with pytest.raises(ValueError, match="non-vectorized"):
+        sf.apply("mean", axis=1, parallel=True)
+
+
+def test_apply_parallel_rejects_axis_0():
+    sf = SpectraFrame(np.arange(12).reshape(3, 4))
+    with pytest.raises(ValueError, match="axis=1"):
+        sf.apply(_row_sum, axis=0, parallel=True)
+
+
+def test_apply_parallel_rejects_groupby():
+    sf = SpectraFrame(np.arange(12).reshape(3, 4), data={"group": ["A", "A", "B"]})
+    with pytest.raises(ValueError, match="groupby"):
+        sf.apply(_row_sum, groupby="group", parallel=True)
+
+
+def test_apply_parallel_rejects_non_pickleable_callable():
+    sf = SpectraFrame(np.arange(12).reshape(3, 4))
+    with pytest.raises(ValueError, match="pickleable"):
+        sf.apply(lambda x: float(np.sum(x)), axis=1, parallel=True)
+
+
+def test_apply_parallel_rejects_invalid_chunksize():
+    sf = SpectraFrame(np.arange(12).reshape(3, 4))
+    with pytest.raises(ValueError, match="chunksize"):
+        sf.apply(_row_sum, axis=1, parallel=True, chunksize=0)

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -990,6 +990,15 @@ class TestSpectraFrameBaseline:
         result = sf.sbaseline("rubberband")
         assert np.array_equal(result.spc[0, :], signal)
 
+    def test_baseline_threaded(self):
+        wl = 400 + np.arange(0, 10, 2)
+        signal = np.array([0, 5, 10, 5, 0])
+        bl = 10 + 5 * (wl - 400)
+        sf = SpectraFrame(signal + bl, wl=wl)
+
+        result = sf.baseline("rubberband", single_threaded=False)
+        assert np.array_equal(result.spc[0, :], bl)
+
 
 class TestSpectaFrameNormalize:
     def test_normalize(self):

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 from numpy.testing import assert_array_equal, assert_allclose
 from pandas.testing import assert_frame_equal, assert_series_equal, assert_index_equal
 import pytest
@@ -968,6 +969,19 @@ class TestSpectraFramePlot:
         frame.plot(rows="B", columns="A")
         frame.plot(rows="B", columns=[1, 2, 3, 4, 5, 6])
         frame.plot(columns="B", rows=[1, 2, 3, 4, 5, 6])
+
+    def test_plot_with_many_continuous_colors(self):
+        nspc = 300
+        frame = SpectraFrame(
+            np.arange(nspc * 4).reshape((nspc, 4)),
+            wl=[400, 600, 800, 1000],
+            data=pd.DataFrame({"concentration": np.linspace(0, 1, nspc)}),
+        )
+
+        fig, axs = frame.plot(colors="concentration", palette="viridis")
+
+        assert len(axs[0, 0].get_lines()) == nspc
+        plt.close(fig)
 
 
 class TestSpectraFrameMisc:

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -990,15 +990,6 @@ class TestSpectraFrameBaseline:
         result = sf.sbaseline("rubberband")
         assert np.array_equal(result.spc[0, :], signal)
 
-    def test_baseline_threaded(self):
-        wl = 400 + np.arange(0, 10, 2)
-        signal = np.array([0, 5, 10, 5, 0])
-        bl = 10 + 5 * (wl - 400)
-        sf = SpectraFrame(signal + bl, wl=wl)
-
-        result = sf.baseline("rubberband", single_threaded=False)
-        assert np.array_equal(result.spc[0, :], bl)
-
 
 class TestSpectaFrameNormalize:
     def test_normalize(self):


### PR DESCRIPTION
### Motivation
- Avoid duplicated baseline-construction logic between single-threaded and threaded paths and make per-thread baseline creation explicit.
- Keep the `single_threaded` API as a keyword-only option on `SpectraFrame.baseline` for clarity and backward compatibility.

### Description
- Added a module-level helper ` _thread_baseline_func(wl, method, kwargs)` that returns a callable performing baseline estimation for a single spectrum using either `rubberband` or a `pybaselines.Baseline` method.
- Updated `SpectraFrame.baseline` to accept `*, single_threaded: bool = True` and to use `_thread_baseline_func` for the single-threaded path (via `self.apply`) and for each worker in the multithreaded path (via `ThreadPoolExecutor`).
- Consolidated error handling for unknown methods into the helper and removed duplicated code inside `baseline`.
- Documented the baseline API and `single_threaded` option in `docs/user-guide/manipulation.md` and added `test_baseline_threaded` to `tests/test_spectra.py` to exercise the threaded path.

### Testing
- Ran `pytest tests/test_spectra.py -k baseline`, which executed the baseline-related tests and reported success (`2 passed, 67 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d7bf76f883329d954b84ad1cf039)